### PR TITLE
CI: Docker Multi-Platform Image

### DIFF
--- a/.github/workflows/ci-feature.yml
+++ b/.github/workflows/ci-feature.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "feature/**"
-      - master
 
 jobs:
   build-and-test:

--- a/.github/workflows/cr-master.yml
+++ b/.github/workflows/cr-master.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - master
-    - feature/vhvapm-547
 
 env:
   REGISTRY_IMAGE: inspectit/inspectit-gepard-agent

--- a/.github/workflows/cr-master.yml
+++ b/.github/workflows/cr-master.yml
@@ -28,11 +28,13 @@ jobs:
           build-scan-terms-of-service-url: 'https://gradle.com/terms-of-service'
           build-scan-terms-of-service-agree: 'yes'
 
-      - name: Test
-        run: ./gradlew test
+      # TODO: Include tests before merging to master
+
+      #- name: Test
+      #  run: ./gradlew test
 
       - name: Build
-        run: ./gradlew extendedAgent
+        run: ./gradlew extendedAgent -x test
 
   build-image:
     runs-on: ubuntu-latest
@@ -73,7 +75,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
-          file: "/docker/Dockerfile-CR"
+          file: "./docker/Dockerfile-CR"
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true

--- a/.github/workflows/cr-master.yml
+++ b/.github/workflows/cr-master.yml
@@ -73,8 +73,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
-          context: "{{defaultContext}}"
-          file: "{context}/docker/Dockerfile-CR"
+          file: "/docker/Dockerfile-CR"
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true

--- a/.github/workflows/cr-master.yml
+++ b/.github/workflows/cr-master.yml
@@ -9,16 +9,8 @@ env:
   REGISTRY_IMAGE: inspectit/inspectit-gepard-agent
 
 jobs:
-  build:
+  build-agent:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm/v6
-          - linux/arm/v7
-          - linux/arm64
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -42,6 +34,18 @@ jobs:
       - name: Build
         run: ./gradlew extendedAgent
 
+  build-image:
+    runs-on: ubuntu-latest
+    needs: build-agent
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/arm64
+    steps:
       - name: Prepare
         run: |
           platform=${{ matrix.platform }}

--- a/.github/workflows/cr-master.yml
+++ b/.github/workflows/cr-master.yml
@@ -96,7 +96,7 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     needs:
-      - build
+      - build-image
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4

--- a/.github/workflows/cr-master.yml
+++ b/.github/workflows/cr-master.yml
@@ -3,6 +3,7 @@ name: Master Branch Continuous Release
 on:
   push:
     branches:
+    - master
     - feature/vhvapm-547
 
 env:
@@ -28,10 +29,8 @@ jobs:
           build-scan-terms-of-service-url: 'https://gradle.com/terms-of-service'
           build-scan-terms-of-service-agree: 'yes'
 
-      # TODO: Include tests before merging to master
-
-      #- name: Test
-      #  run: ./gradlew test
+      - name: Test
+        run: ./gradlew test
 
       - name: Build
         run: ./gradlew extendedAgent -x test

--- a/.github/workflows/cr-master.yml
+++ b/.github/workflows/cr-master.yml
@@ -83,11 +83,6 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: actions/download-artifact@master
-        with:
-          name: build
-          path: build
-
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6

--- a/.github/workflows/cr-master.yml
+++ b/.github/workflows/cr-master.yml
@@ -54,6 +54,9 @@ jobs:
           - linux/arm/v7
           - linux/arm64
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Prepare
         run: |
           platform=${{ matrix.platform }}

--- a/.github/workflows/cr-master.yml
+++ b/.github/workflows/cr-master.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/upload-artifact@master
         with:
           name: build
-          path: build/
+          path: build
 
   build-image:
     runs-on: ubuntu-latest
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/download-artifact@master
         with:
           name: build
-          path: /
+          path: build
 
       - name: Build and push by digest
         id: build

--- a/.github/workflows/cr-master.yml
+++ b/.github/workflows/cr-master.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Build
         run: ./gradlew extendedAgent -x test
 
+      - uses: actions/upload-artifact@master
+        with:
+          name: build
+          path: build/
+
   build-image:
     runs-on: ubuntu-latest
     needs: build-agent
@@ -70,6 +75,11 @@ jobs:
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: actions/download-artifact@master
+        with:
+          name: build
+          path: /
 
       - name: Build and push by digest
         id: build

--- a/.github/workflows/cr-master.yml
+++ b/.github/workflows/cr-master.yml
@@ -1,3 +1,19 @@
+# This workflow is triggered on pushes to the master branch.
+# It builds the agent and creates a multi-arch image for it.
+# The image is then pushed to Docker Hub.
+#
+# The workflow consists of three jobs:
+# 1. build-agent: Builds the agent and uploads the resulting JAR as an artifact.
+# 2. build-image: Builds a Docker image for multiple platforms with the matrix strategy.
+# 3. merge: Merges the images for the different platforms into a manifest list and pushes it to Docker Hub.
+
+# To make the build faster, we use a matrix strategy to build the image for multiple platforms in parallel.
+# The build of the first job is copied over to the image build jobs, so that the application build is only done once.
+# QUEMU is used to emulate the different platforms on the GitHub runner.
+
+# For more information about how to build multi-arch images and advanced settings with Docker Buildx in GitHub actions, see:
+# https://docs.docker.com/build/ci/github-actions/multi-platform/
+
 name: Master Branch Continuous Release
 
 on:

--- a/.github/workflows/cr-master.yml
+++ b/.github/workflows/cr-master.yml
@@ -1,0 +1,127 @@
+name: Master Branch Continuous Release
+
+on:
+  push:
+    branches:
+    - feature/vhvapm-547
+
+env:
+  REGISTRY_IMAGE: inspectit/inspectit-gepard-agent
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/arm64
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
+      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+        with:
+          build-scan-publish: true
+          build-scan-terms-of-service-url: 'https://gradle.com/terms-of-service'
+          build-scan-terms-of-service-agree: 'yes'
+
+      - name: Test
+        run: ./gradlew test
+
+      - name: Build
+        run: ./gradlew extendedAgent
+
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV          
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: "{{defaultContext}}"
+          file: "{context}/docker/Dockerfile-CR"
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"          
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)          
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/cr-master.yml
+++ b/.github/workflows/cr-master.yml
@@ -36,10 +36,11 @@ jobs:
       - name: Build
         run: ./gradlew extendedAgent -x test
 
-      - uses: actions/upload-artifact@master
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
         with:
-          name: build
-          path: build
+          name: agent-artifact
+          path: build/libs/inspectit-gepard-agent.jar
 
   build-image:
     runs-on: ubuntu-latest
@@ -64,6 +65,12 @@ jobs:
         with:
           images: ${{ env.REGISTRY_IMAGE }}
 
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: agent-artifact
+          path: ./  # Download artifact to the root of the Docker build context
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -85,6 +92,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
+          context: .
           file: "./docker/Dockerfile-CR"
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker/Dockerfile-CR
+++ b/docker/Dockerfile-CR
@@ -1,7 +1,7 @@
 # lightweight base image
 FROM busybox
 
-COPY ./build/libs/inspectit-gepard-agent.jar .
+COPY ./inspectit-gepard-agent.jar .
 COPY ./docker/entrypoint.sh /entrypoint.sh
 
 RUN chmod go+r inspectit-gepard-agent.jar

--- a/docker/Dockerfile-CR
+++ b/docker/Dockerfile-CR
@@ -1,0 +1,9 @@
+# lightweight base image
+FROM busybox
+
+COPY /build/libs/inspectit-gepard-agent.jar .
+COPY /docker/entrypoint.sh /entrypoint.sh
+
+RUN chmod go+r inspectit-gepard-agent.jar
+
+ENTRYPOINT ["sh", "/entrypoint.sh"]

--- a/docker/Dockerfile-CR
+++ b/docker/Dockerfile-CR
@@ -1,8 +1,8 @@
 # lightweight base image
 FROM busybox
 
-COPY /build/libs/inspectit-gepard-agent.jar .
-COPY /docker/entrypoint.sh /entrypoint.sh
+COPY ./build/libs/inspectit-gepard-agent.jar .
+COPY ./docker/entrypoint.sh /entrypoint.sh
 
 RUN chmod go+r inspectit-gepard-agent.jar
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,6 @@
 rm -rf agent/*
 # Copy agent jar into shared volume
-mkdir agent
+mkdir -p agent
 cp inspectit-gepard-agent.jar agent/inspectit-gepard-agent.jar
 # Keep the container running
 while true; do sleep 2; done;

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,6 @@
 rm -rf agent/*
 # Copy agent jar into shared volume
+mkdir agent
 cp inspectit-gepard-agent.jar agent/inspectit-gepard-agent.jar
 # Keep the container running
 while true; do sleep 2; done;


### PR DESCRIPTION
This PR adds a basic CI-Workflow to release a Multi-Platform Image on the InspectIT Docker Hub, when pushing to main.

This is required, cause we want to deploy a Integration / Demo-Environment on AWS for showcase purposes.

@EddeCCC: I kept the palantir-gradle-docker-plugin in the build-Skript for local builds, but since it is deprecated and the docker-build-and-push action works pretty well, I´m not using it in the ci. 