### PR TITLE
fix: make multiple scopes work.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,9 @@ plugins {
     id "pl.allegro.tech.build.axion-release" version "1.17.2"
 
     id "com.palantir.docker" version "0.36.0"
+
+    id 'jacoco'
+
 }
 
 group 'rocks.inspectit.gepard.agent'
@@ -167,6 +170,9 @@ tasks {
         systemProperty 'io.opentelemetry.smoketest.agentPath', configurations.otel.singleFile.absolutePath
         systemProperty 'io.opentelemetry.smoketest.extendedAgentPath', tasks.extendedAgent.archiveFile.get().asFile.absolutePath
         systemProperty 'io.opentelemetry.smoketest.extensionPath', tasks.shadowJar.archiveFile.get().asFile.absolutePath
+
+        finalizedBy jacocoTestReport
+
     }
 
     compileJava {
@@ -185,4 +191,6 @@ tasks {
         dockerfile file('docker/Dockerfile')
         files 'docker/entrypoint.sh', agentJar.get().asFile
     }
+
+    jacocoTestReport.dependsOn(test)
 }

--- a/src/main/java/rocks/inspectit/gepard/agent/internal/configuration/model/instrumentation/InstrumentationConfiguration.java
+++ b/src/main/java/rocks/inspectit/gepard/agent/internal/configuration/model/instrumentation/InstrumentationConfiguration.java
@@ -8,7 +8,7 @@ import java.util.List;
  */
 public class InstrumentationConfiguration {
 
-  private List<Scope> scopes;
+  private final List<Scope> scopes;
 
   public InstrumentationConfiguration() {
     this.scopes = List.of();
@@ -22,7 +22,7 @@ public class InstrumentationConfiguration {
     return scopes;
   }
 
-  public Scope getScopeByFqn(String fqn) {
-    return scopes.stream().filter(scope -> scope.getFqn().equals(fqn)).findFirst().orElse(null);
+  public List<Scope> getAllScopeWithFqn(String fqn) {
+    return scopes.stream().filter(scope -> scope.getFqn().equals(fqn)).toList();
   }
 }

--- a/src/main/java/rocks/inspectit/gepard/agent/internal/configuration/model/instrumentation/InstrumentationConfiguration.java
+++ b/src/main/java/rocks/inspectit/gepard/agent/internal/configuration/model/instrumentation/InstrumentationConfiguration.java
@@ -22,7 +22,7 @@ public class InstrumentationConfiguration {
     return scopes;
   }
 
-  public List<Scope> getAllScopeWithFqn(String fqn) {
+  public List<Scope> getAllMatchingScopes(String fqn) {
     return scopes.stream().filter(scope -> scope.getFqn().equals(fqn)).toList();
   }
 }

--- a/src/main/java/rocks/inspectit/gepard/agent/resolver/ConfigurationResolver.java
+++ b/src/main/java/rocks/inspectit/gepard/agent/resolver/ConfigurationResolver.java
@@ -1,12 +1,10 @@
 package rocks.inspectit.gepard.agent.resolver;
 
-import java.util.*;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import net.bytebuddy.matcher.ElementMatchers;
 import rocks.inspectit.gepard.agent.internal.configuration.model.instrumentation.InstrumentationConfiguration;
-import rocks.inspectit.gepard.agent.internal.configuration.model.instrumentation.Scope;
+import rocks.inspectit.gepard.agent.resolver.scope.ScopeResolver;
 
 /**
  * Utility class to resolve the {@link InstrumentationConfiguration} and determine whether class
@@ -14,10 +12,10 @@ import rocks.inspectit.gepard.agent.internal.configuration.model.instrumentation
  */
 public class ConfigurationResolver {
 
-  private final ConfigurationHolder holder;
+  private final ScopeResolver scopeResolver;
 
   private ConfigurationResolver(ConfigurationHolder holder) {
-    this.holder = holder;
+    this.scopeResolver = new ScopeResolver(holder);
   }
 
   /**
@@ -52,63 +50,25 @@ public class ConfigurationResolver {
   }
 
   /**
+   * Gets a matcher for the methods of the provided type, based on the configured scope.
+   *
+   * @param typeDescription the type to build the method matcher for
+   * @return a matcher for the methods of the provided type
+   */
+  public ElementMatcher.Junction<MethodDescription> getMethodMatcher(
+          TypeDescription typeDescription) {
+
+    return scopeResolver.buildMethodMatcher(typeDescription);
+  }
+
+  /**
    * Checks, if the provided class name requires instrumentation.
    *
    * @param fullyQualifiedName the full name of the class
    * @return true, if the provided class should be instrumented
    */
   private boolean shouldInstrument(String fullyQualifiedName) {
-    InstrumentationConfiguration configuration = getConfiguration();
-
-    return !shouldIgnore(fullyQualifiedName)
-        && configuration.getScopes().stream()
-            .anyMatch(scope -> scope.getFqn().equals(fullyQualifiedName) && scope.isEnabled());
+    return scopeResolver.shouldInstrument(fullyQualifiedName);
   }
 
-  /**
-   * Builds a matcher for the methods of the provided type, based on the configured scope.
-   *
-   * @param typeDescription the type to build the method matcher for
-   * @return a matcher for the methods of the provided type
-   */
-  public ElementMatcher.Junction<MethodDescription> buildMethodMatcher(
-      TypeDescription typeDescription) {
-
-    // Get the configuration and retrieve all matching scopes
-    List<Scope> scopes = getConfiguration().getAllScopeWithFqn(typeDescription.getName());
-
-    // Collect method names from the scopes, skipping null or empty method lists
-    List<String> methodNames =
-        scopes.stream()
-            .map(Scope::getMethods) // Map Scope to its methods list
-            .filter(Objects::nonNull) // Filter out null method lists
-            .flatMap(Collection::stream) // Flatten the list of methods
-            .toList();
-
-    // If no method names were found, match any method
-    if (methodNames.isEmpty()) {
-      return ElementMatchers.isMethod();
-    }
-
-    // Otherwise, match by method names
-    return ElementMatchers.namedOneOf(methodNames.toArray(String[]::new));
-  }
-
-  /**
-   * @return the current {@link InstrumentationConfiguration}
-   */
-  private InstrumentationConfiguration getConfiguration() {
-    return holder.getConfiguration().getInstrumentation();
-  }
-
-  /**
-   * Checks, if the type should be able to be instrumented. Currently, we don't instrument lambda-
-   * or array classes.
-   *
-   * @param fullyQualifiedName the full name of the class
-   * @return true, if the provided type should NOT be able to be instrumented
-   */
-  private boolean shouldIgnore(String fullyQualifiedName) {
-    return fullyQualifiedName.contains("$$Lambda") || fullyQualifiedName.startsWith("[");
-  }
 }

--- a/src/main/java/rocks/inspectit/gepard/agent/resolver/ConfigurationResolver.java
+++ b/src/main/java/rocks/inspectit/gepard/agent/resolver/ConfigurationResolver.java
@@ -56,7 +56,7 @@ public class ConfigurationResolver {
    * @return a matcher for the methods of the provided type
    */
   public ElementMatcher.Junction<MethodDescription> getMethodMatcher(
-          TypeDescription typeDescription) {
+      TypeDescription typeDescription) {
 
     return scopeResolver.buildMethodMatcher(typeDescription);
   }
@@ -70,5 +70,4 @@ public class ConfigurationResolver {
   private boolean shouldInstrument(String fullyQualifiedName) {
     return scopeResolver.shouldInstrument(fullyQualifiedName);
   }
-
 }

--- a/src/main/java/rocks/inspectit/gepard/agent/resolver/matcher/CustomElementMatchers.java
+++ b/src/main/java/rocks/inspectit/gepard/agent/resolver/matcher/CustomElementMatchers.java
@@ -23,7 +23,7 @@ public class CustomElementMatchers {
    */
   public static <T extends NamedElement> ElementMatcher.Junction<T> nameIs(String methodName) {
 
-    if(methodName.isEmpty()){
+    if (methodName.isEmpty()) {
       return null;
     }
 

--- a/src/main/java/rocks/inspectit/gepard/agent/resolver/matcher/CustomElementMatchers.java
+++ b/src/main/java/rocks/inspectit/gepard/agent/resolver/matcher/CustomElementMatchers.java
@@ -22,6 +22,11 @@ public class CustomElementMatchers {
    * the name settings are available.
    */
   public static <T extends NamedElement> ElementMatcher.Junction<T> nameIs(String methodName) {
+
+    if(methodName.isEmpty()){
+      return null;
+    }
+
     return new NameMatcher<>(new StringMatcher(methodName, StringMatcher.Mode.EQUALS_FULLY));
   }
 }

--- a/src/main/java/rocks/inspectit/gepard/agent/resolver/matcher/CustomElementMatchers.java
+++ b/src/main/java/rocks/inspectit/gepard/agent/resolver/matcher/CustomElementMatchers.java
@@ -18,8 +18,8 @@ public class CustomElementMatchers {
 
   /**
    * Creates an {@link ElementMatcher} matching items with the given name settings. Currently, there
-   * are no nameSettings available, so we will just use the methodName. Will be enhanced, as soon as the
-   * name settings are available.
+   * are no nameSettings available, so we will just use the methodName. Will be enhanced, as soon as
+   * the name settings are available.
    */
   public static <T extends NamedElement> ElementMatcher.Junction<T> nameIs(String methodName) {
     return new NameMatcher<>(new StringMatcher(methodName, StringMatcher.Mode.EQUALS_FULLY));

--- a/src/main/java/rocks/inspectit/gepard/agent/resolver/matcher/CustomElementMatchers.java
+++ b/src/main/java/rocks/inspectit/gepard/agent/resolver/matcher/CustomElementMatchers.java
@@ -1,0 +1,27 @@
+package rocks.inspectit.gepard.agent.resolver.matcher;
+
+import net.bytebuddy.description.NamedElement;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.NameMatcher;
+import net.bytebuddy.matcher.StringMatcher;
+
+/**
+ * This class is a copy InspectIT Ocelot: <a
+ * href="https://github.com/inspectIT/inspectit-ocelot/blob/e2e8a4c06ab696a85feee40d2c1f82ec91d3eb07/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/instrumentation/config/matcher/SpecialElementMatchers.java#L33">
+ * SpecialElementMatchers </a>
+ *
+ * <p>Original Author: The InspectIT Ocelot team
+ *
+ * <p>Date Copied: 09.09.2024 This class provides advanced and custom ElementMatchers.
+ */
+public class CustomElementMatchers {
+
+  /**
+   * Creates an {@link ElementMatcher} matching items with the given name settings. Currently, there
+   * are no nameSettings available, so we will just use the methodName. Will be enhanced, as soon as the
+   * name settings are available.
+   */
+  public static <T extends NamedElement> ElementMatcher.Junction<T> nameIs(String methodName) {
+    return new NameMatcher<>(new StringMatcher(methodName, StringMatcher.Mode.EQUALS_FULLY));
+  }
+}

--- a/src/main/java/rocks/inspectit/gepard/agent/resolver/matcher/MatcherChainBuilder.java
+++ b/src/main/java/rocks/inspectit/gepard/agent/resolver/matcher/MatcherChainBuilder.java
@@ -5,13 +5,21 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 import net.bytebuddy.matcher.ElementMatcher;
 
 /**
+ * This class is a copy InspectIT Ocelot: <a
+ * href="https://github.com/inspectIT/inspectit-ocelot/blob/master/inspectit-ocelot-core/src/main/java/rocks/inspectit/ocelot/core/instrumentation/config/matcher/MatcherChainBuilder.java">
+ * MatcherChainBuilder </a>
+ *
+ * <p>Original Author: The InspectIT Ocelot team
+ *
+ * <p>Date Copied: 09.09.2024
+
  * Helper class for building and linking {@link ElementMatcher}s. All methods are null-safe. Adding
  * a null matcher will not have an effect on the matcher in construction.
  *
  * @param <T> The matchers generic type. Most of the time it will be TypeDescription or
  *     MethodDescription.
  */
-public class MethodMatcherChainBuilder<T> {
+public class MatcherChainBuilder<T> {
 
   private ElementMatcher.Junction<T> matcher = null;
 

--- a/src/main/java/rocks/inspectit/gepard/agent/resolver/matcher/MatcherChainBuilder.java
+++ b/src/main/java/rocks/inspectit/gepard/agent/resolver/matcher/MatcherChainBuilder.java
@@ -2,6 +2,7 @@ package rocks.inspectit.gepard.agent.resolver.matcher;
 
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
+import java.util.Objects;
 import net.bytebuddy.matcher.ElementMatcher;
 
 /**
@@ -12,20 +13,25 @@ import net.bytebuddy.matcher.ElementMatcher;
  * <p>Original Author: The InspectIT Ocelot team
  *
  * <p>Date Copied: 09.09.2024
-
- * Helper class for building and linking {@link ElementMatcher}s. All methods are null-safe. Adding
- * a null matcher will not have an effect on the matcher in construction.
+ *
+ * <p>Helper class for building and linking {@link ElementMatcher}s. All methods are null-safe.
+ * Adding a null matcher will not have an effect on the matcher in construction.
  *
  * @param <T> The matchers generic type. Most of the time it will be TypeDescription or
  *     MethodDescription.
  */
 public class MatcherChainBuilder<T> {
 
-  private ElementMatcher.Junction<T> matcher = null;
+  private ElementMatcher.Junction<T> matcher;
 
+  /**
+   * Adds the given matcher to the chain using an OR operation.
+   *
+   * @param nextMatcher the matcher to add
+   */
   public void or(ElementMatcher.Junction<T> nextMatcher) {
-    if (nextMatcher != null) {
-      if (matcher == null) {
+    if (Objects.nonNull(nextMatcher)) {
+      if (Objects.isNull(matcher)) {
         matcher = nextMatcher;
       } else {
         matcher = matcher.or(nextMatcher);
@@ -33,9 +39,14 @@ public class MatcherChainBuilder<T> {
     }
   }
 
+  /**
+   * Adds the given matcher to the chain using an AND operation.
+   *
+   * @param nextMatcher the matcher to add
+   */
   public void and(ElementMatcher.Junction<T> nextMatcher) {
-    if (nextMatcher != null) {
-      if (matcher == null) {
+    if (Objects.nonNull(nextMatcher)) {
+      if (Objects.isNull(matcher)) {
         matcher = nextMatcher;
       } else {
         matcher = matcher.and(nextMatcher);
@@ -43,8 +54,13 @@ public class MatcherChainBuilder<T> {
     }
   }
 
+  /**
+   * Adds the negation of the given matcher to the chain using an AND operation.
+   *
+   * @param nextMatcher the matcher to negate and add
+   */
   public void and(boolean condition, ElementMatcher.Junction<T> nextMatcher) {
-    if (nextMatcher != null) {
+    if (Objects.nonNull(nextMatcher)) {
       if (condition) {
         and(nextMatcher);
       } else {
@@ -58,6 +74,6 @@ public class MatcherChainBuilder<T> {
   }
 
   public boolean isEmpty() {
-    return matcher == null;
+    return Objects.isNull(matcher);
   }
 }

--- a/src/main/java/rocks/inspectit/gepard/agent/resolver/matcher/MethodMatcherChainBuilder.java
+++ b/src/main/java/rocks/inspectit/gepard/agent/resolver/matcher/MethodMatcherChainBuilder.java
@@ -5,8 +5,8 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 import net.bytebuddy.matcher.ElementMatcher;
 
 /**
- * Helper class for building and linking {@link ElementMatcher}s. All methods are null-safe.
- * Adding a null matcher will not have an effect on the matcher in construction.
+ * Helper class for building and linking {@link ElementMatcher}s. All methods are null-safe. Adding
+ * a null matcher will not have an effect on the matcher in construction.
  *
  * @param <T> The matchers generic type. Most of the time it will be TypeDescription or
  *     MethodDescription.

--- a/src/main/java/rocks/inspectit/gepard/agent/resolver/matcher/MethodMatcherChainBuilder.java
+++ b/src/main/java/rocks/inspectit/gepard/agent/resolver/matcher/MethodMatcherChainBuilder.java
@@ -1,0 +1,55 @@
+package rocks.inspectit.gepard.agent.resolver.matcher;
+
+import static net.bytebuddy.matcher.ElementMatchers.not;
+
+import net.bytebuddy.matcher.ElementMatcher;
+
+/**
+ * Helper class for building and linking {@link ElementMatcher}s. All methods are null-safe.
+ * Adding a null matcher will not have an effect on the matcher in construction.
+ *
+ * @param <T> The matchers generic type. Most of the time it will be TypeDescription or
+ *     MethodDescription.
+ */
+public class MethodMatcherChainBuilder<T> {
+
+  private ElementMatcher.Junction<T> matcher = null;
+
+  public void or(ElementMatcher.Junction<T> nextMatcher) {
+    if (nextMatcher != null) {
+      if (matcher == null) {
+        matcher = nextMatcher;
+      } else {
+        matcher = matcher.or(nextMatcher);
+      }
+    }
+  }
+
+  public void and(ElementMatcher.Junction<T> nextMatcher) {
+    if (nextMatcher != null) {
+      if (matcher == null) {
+        matcher = nextMatcher;
+      } else {
+        matcher = matcher.and(nextMatcher);
+      }
+    }
+  }
+
+  public void and(boolean condition, ElementMatcher.Junction<T> nextMatcher) {
+    if (nextMatcher != null) {
+      if (condition) {
+        and(nextMatcher);
+      } else {
+        and(not(nextMatcher));
+      }
+    }
+  }
+
+  public ElementMatcher.Junction<T> build() {
+    return matcher;
+  }
+
+  public boolean isEmpty() {
+    return matcher == null;
+  }
+}

--- a/src/main/java/rocks/inspectit/gepard/agent/resolver/scope/ScopeResolver.java
+++ b/src/main/java/rocks/inspectit/gepard/agent/resolver/scope/ScopeResolver.java
@@ -10,7 +10,7 @@ import rocks.inspectit.gepard.agent.internal.configuration.model.instrumentation
 import rocks.inspectit.gepard.agent.internal.configuration.model.instrumentation.Scope;
 import rocks.inspectit.gepard.agent.resolver.ConfigurationHolder;
 import rocks.inspectit.gepard.agent.resolver.matcher.CustomElementMatchers;
-import rocks.inspectit.gepard.agent.resolver.matcher.MethodMatcherChainBuilder;
+import rocks.inspectit.gepard.agent.resolver.matcher.MatcherChainBuilder;
 
 /**
  * This class is used to resolve the {@link Scope} based on the {@link Scope} List, contained in the
@@ -100,8 +100,8 @@ public class ScopeResolver {
    */
   private ElementMatcher.Junction<MethodDescription> buildMatcherForMethods(
       List<String> methodNames) {
-    MethodMatcherChainBuilder<MethodDescription> matcherChainBuilder =
-        new MethodMatcherChainBuilder<>();
+    MatcherChainBuilder<MethodDescription> matcherChainBuilder =
+        new MatcherChainBuilder<>();
     methodNames.forEach(
         methodName -> matcherChainBuilder.or(CustomElementMatchers.nameIs(methodName)));
     return matcherChainBuilder.build();

--- a/src/main/java/rocks/inspectit/gepard/agent/resolver/scope/ScopeResolver.java
+++ b/src/main/java/rocks/inspectit/gepard/agent/resolver/scope/ScopeResolver.java
@@ -18,7 +18,7 @@ import rocks.inspectit.gepard.agent.resolver.matcher.MatcherChainBuilder;
  */
 public class ScopeResolver {
 
-  ConfigurationHolder holder;
+  private final ConfigurationHolder holder;
 
   public ScopeResolver(ConfigurationHolder holder) {
     this.holder = holder;
@@ -50,7 +50,7 @@ public class ScopeResolver {
 
     List<Scope> scopes = getAllMatchingScopes(typeDescription.getName());
 
-    if (containsWholeClassScope(scopes)) {
+    if (containsAllMethodsScope(scopes)) {
       return ElementMatchers.isMethod();
     }
 
@@ -65,7 +65,7 @@ public class ScopeResolver {
    * @param scope the scope to check
    * @return true if the scope contains method definitions
    */
-  private boolean isWholeClassScope(Scope scope) {
+  private boolean isAllMethodsScope(Scope scope) {
     return scope.getMethods() == null || scope.getMethods().isEmpty();
   }
 
@@ -75,8 +75,8 @@ public class ScopeResolver {
    * @param scopes the list of scopes to check
    * @return true if the list of scopes contains at least one whole class scope
    */
-  private boolean containsWholeClassScope(List<Scope> scopes) {
-    return scopes.stream().anyMatch(this::isWholeClassScope);
+  private boolean containsAllMethodsScope(List<Scope> scopes) {
+    return scopes.stream().anyMatch(this::isAllMethodsScope);
   }
 
   /**
@@ -100,8 +100,7 @@ public class ScopeResolver {
    */
   private ElementMatcher.Junction<MethodDescription> buildMatcherForMethods(
       List<String> methodNames) {
-    MatcherChainBuilder<MethodDescription> matcherChainBuilder =
-        new MatcherChainBuilder<>();
+    MatcherChainBuilder<MethodDescription> matcherChainBuilder = new MatcherChainBuilder<>();
     methodNames.forEach(
         methodName -> matcherChainBuilder.or(CustomElementMatchers.nameIs(methodName)));
     return matcherChainBuilder.build();
@@ -127,6 +126,12 @@ public class ScopeResolver {
     return holder.getConfiguration().getInstrumentation().getScopes();
   }
 
+  /**
+   * Returns all scopes, which match the provided fully qualified name.
+   *
+   * @param fqn the fully qualified name to match
+   * @return the list of matching scopes
+   */
   private List<Scope> getAllMatchingScopes(String fqn) {
     return holder.getConfiguration().getInstrumentation().getAllMatchingScopes(fqn);
   }

--- a/src/main/java/rocks/inspectit/gepard/agent/resolver/scope/ScopeResolver.java
+++ b/src/main/java/rocks/inspectit/gepard/agent/resolver/scope/ScopeResolver.java
@@ -1,0 +1,133 @@
+package rocks.inspectit.gepard.agent.resolver.scope;
+
+import java.util.Collection;
+import java.util.List;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+import rocks.inspectit.gepard.agent.internal.configuration.model.instrumentation.InstrumentationConfiguration;
+import rocks.inspectit.gepard.agent.internal.configuration.model.instrumentation.Scope;
+import rocks.inspectit.gepard.agent.resolver.ConfigurationHolder;
+import rocks.inspectit.gepard.agent.resolver.matcher.CustomElementMatchers;
+import rocks.inspectit.gepard.agent.resolver.matcher.MethodMatcherChainBuilder;
+
+/**
+ * This class is used to resolve the {@link Scope} based on the {@link Scope} List, contained
+ * in the {@link InstrumentationConfiguration}.
+ */
+public class ScopeResolver {
+
+  ConfigurationHolder holder;
+
+  public ScopeResolver(ConfigurationHolder holder) {
+    this.holder = holder;
+  }
+
+  /**
+   * Checks, if the provided class name requires instrumentation.
+   *
+   * @param fullyQualifiedName the full name of the class
+   * @return true, if the provided class should be instrumented
+   */
+  public boolean shouldInstrument(String fullyQualifiedName) {
+
+    List<Scope> scopes = getScopes();
+
+    return !shouldIgnore(fullyQualifiedName)
+        && scopes.stream()
+            .anyMatch(scope -> scope.getFqn().equals(fullyQualifiedName) && scope.isEnabled());
+  }
+
+  /**
+   * Builds a matcher for the methods of the provided type.
+   *
+   * @param typeDescription the type to build the method matcher for
+   * @return the matcher for the methods
+   */
+  public ElementMatcher.Junction<MethodDescription> buildMethodMatcher(
+      TypeDescription typeDescription) {
+
+    List<Scope> scopes = getAllMatchingScopes(typeDescription.getName());
+
+    if (containsWholeClassScope(scopes)) {
+      return ElementMatchers.isMethod();
+    }
+
+    List<String> methodNames = collectMethodNames(scopes);
+
+    return buildMatcherForMethods(methodNames);
+  }
+
+  /**
+   * Checks if the provided scope contains method definitions.
+   *
+   * @param scope the scope to check
+   * @return true if the scope contains method definitions
+   */
+  private boolean isWholeClassScope(Scope scope) {
+    return scope.getMethods() == null || scope.getMethods().isEmpty();
+  }
+
+  /**
+   * Checks if the provided list of scopes contains at least one whole class scope.
+   *
+   * @param scopes the list of scopes to check
+   * @return true if the list of scopes contains at least one whole class scope
+   */
+  private boolean containsWholeClassScope(List<Scope> scopes) {
+    return scopes.stream().anyMatch(this::isWholeClassScope);
+  }
+
+  /**
+   * Collects all method names from the provided list of scopes.
+   *
+   * @param scopes the list of scopes to collect the method names from
+   * @return the list of method names
+   */
+  private List<String> collectMethodNames(List<Scope> scopes) {
+    return scopes.stream()
+        .map(Scope::getMethods) // Map Scope to its methods list
+        .flatMap(Collection::stream) // Flatten the list of methods
+        .toList();
+  }
+
+  /**
+   * Builds a matcher for each method name and chains them using 'or'.
+   *
+   * @param methodNames the method names to build matchers for
+   * @return a matcher for the methods
+   */
+  private ElementMatcher.Junction<MethodDescription> buildMatcherForMethods(
+      List<String> methodNames) {
+    MethodMatcherChainBuilder<MethodDescription> matcherChainBuilder =
+        new MethodMatcherChainBuilder<>();
+    methodNames.forEach(
+        methodName -> matcherChainBuilder.or(CustomElementMatchers.nameIs(methodName)));
+    return matcherChainBuilder.build();
+  }
+
+  /**
+   * Checks, if the type should be able to be instrumented. Currently, we don't instrument lambda-
+   * or array classes.
+   *
+   * @param fullyQualifiedName the full name of the class
+   * @return true, if the provided type should NOT be able to be instrumented
+   */
+  private boolean shouldIgnore(String fullyQualifiedName) {
+    return fullyQualifiedName.contains("$$Lambda") || fullyQualifiedName.startsWith("[");
+  }
+
+  /**
+   * Returns the list of scopes from the current {@link InstrumentationConfiguration}.
+   *
+   * @return the list of scopes
+   */
+  private List<Scope> getScopes() {
+    return holder.getConfiguration().getInstrumentation().getScopes();
+  }
+
+  private List<Scope> getAllMatchingScopes(String fqn) {
+    return holder.getConfiguration().getInstrumentation().getAllMatchingScopes(fqn);
+  }
+}

--- a/src/main/java/rocks/inspectit/gepard/agent/resolver/scope/ScopeResolver.java
+++ b/src/main/java/rocks/inspectit/gepard/agent/resolver/scope/ScopeResolver.java
@@ -13,8 +13,8 @@ import rocks.inspectit.gepard.agent.resolver.matcher.CustomElementMatchers;
 import rocks.inspectit.gepard.agent.resolver.matcher.MethodMatcherChainBuilder;
 
 /**
- * This class is used to resolve the {@link Scope} based on the {@link Scope} List, contained
- * in the {@link InstrumentationConfiguration}.
+ * This class is used to resolve the {@link Scope} based on the {@link Scope} List, contained in the
+ * {@link InstrumentationConfiguration}.
  */
 public class ScopeResolver {
 

--- a/src/main/java/rocks/inspectit/gepard/agent/transformation/DynamicTransformer.java
+++ b/src/main/java/rocks/inspectit/gepard/agent/transformation/DynamicTransformer.java
@@ -55,7 +55,7 @@ public class DynamicTransformer implements AgentBuilder.Transformer {
       log.debug("Adding transformation to {}", typeDescription.getName());
 
       ElementMatcher.Junction<MethodDescription> methodMatcher =
-          resolver.buildMethodMatcher(typeDescription);
+          resolver.getMethodMatcher(typeDescription);
 
       builder = builder.visit(Advice.to(InspectitAdvice.class).on(methodMatcher));
 

--- a/src/test/java/rocks/inspectit/gepard/agent/InspectitAgentExtensionTest.java
+++ b/src/test/java/rocks/inspectit/gepard/agent/InspectitAgentExtensionTest.java
@@ -20,5 +20,6 @@ class InspectitAgentExtensionTest {
             .toList();
 
     assertEquals(1, extensions.size());
+    assertEquals("inspectit-gepard", extensions.get(0).extensionName());
   }
 }

--- a/src/test/java/rocks/inspectit/gepard/agent/configuration/http/HttpConfigurationCallbackTest.java
+++ b/src/test/java/rocks/inspectit/gepard/agent/configuration/http/HttpConfigurationCallbackTest.java
@@ -1,0 +1,49 @@
+package rocks.inspectit.gepard.agent.configuration.http;
+
+import static org.mockito.Mockito.*;
+
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import rocks.inspectit.gepard.agent.internal.configuration.observer.ConfigurationReceivedEvent;
+import rocks.inspectit.gepard.agent.internal.configuration.observer.ConfigurationReceivedObserver;
+import rocks.inspectit.gepard.agent.internal.configuration.observer.ConfigurationReceivedSubject;
+
+class HttpConfigurationCallbackTest {
+
+  @Mock private SimpleHttpResponse response;
+
+  @Mock private ConfigurationReceivedObserver observer;
+
+  private HttpConfigurationCallback callback;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    ConfigurationReceivedSubject.getInstance().addObserver(observer);
+    callback = new HttpConfigurationCallback();
+  }
+
+  @Test
+  void testCompleted() {
+    when(response.getCode()).thenReturn(200);
+    when(response.getBodyText()).thenReturn("{}");
+
+    callback.completed(response);
+
+    verify(observer, times(1)).handleConfiguration(any(ConfigurationReceivedEvent.class));
+  }
+
+  @Test
+  void testFailed() {
+    Exception exception = new Exception("Test exception");
+    callback.failed(exception);
+  }
+
+  @Test
+  void testCancelled() {
+    callback.cancelled();
+  }
+}

--- a/src/test/java/rocks/inspectit/gepard/agent/instrumentation/InstrumentationManagerTest.java
+++ b/src/test/java/rocks/inspectit/gepard/agent/instrumentation/InstrumentationManagerTest.java
@@ -1,0 +1,38 @@
+package rocks.inspectit.gepard.agent.instrumentation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import rocks.inspectit.gepard.agent.internal.schedule.InspectitScheduler;
+
+class InstrumentationManagerTest {
+
+  @BeforeEach
+  void setUp() throws NoSuchFieldException, IllegalAccessException {
+    Field field = InspectitScheduler.class.getDeclaredField("instance");
+    field.setAccessible(true);
+    field.set(null, null);
+  }
+
+  @Test
+  void createCreatesNewInstance() {
+    InstrumentationManager manager = InstrumentationManager.create();
+    assertNotNull(manager);
+  }
+
+  @Test
+  void startClassDiscovery() {
+    InstrumentationManager manager = InstrumentationManager.create();
+    manager.startClassDiscovery();
+    assertEquals(1, InspectitScheduler.getInstance().getNumberOfScheduledFutures());
+  }
+
+  @Test
+  void startBatchInstrumentation() {
+    InstrumentationManager manager = InstrumentationManager.create();
+    manager.startBatchInstrumentation(null, null);
+    assertEquals(1, InspectitScheduler.getInstance().getNumberOfScheduledFutures());
+  }
+}

--- a/src/test/java/rocks/inspectit/gepard/agent/resolver/ConfigurationResolverTest.java
+++ b/src/test/java/rocks/inspectit/gepard/agent/resolver/ConfigurationResolverTest.java
@@ -136,7 +136,7 @@ class ConfigurationResolverTest {
    *
    * @param enabled the status of the scope for this test class
    * @param methodNames the method names to be instrumented
-   * @return the scope with the current class as scope
+   * @return the scope with the current class as fqn
    */
   private Scope createScope(boolean enabled, List<String> methodNames) {
     return new Scope(TEST_TYPE.getName(), methodNames, enabled);

--- a/src/test/java/rocks/inspectit/gepard/agent/resolver/ConfigurationResolverTest.java
+++ b/src/test/java/rocks/inspectit/gepard/agent/resolver/ConfigurationResolverTest.java
@@ -86,14 +86,13 @@ class ConfigurationResolverTest {
     ElementMatcher.Junction<MethodDescription> elementMatcher =
         resolver.getMethodMatcher(TEST_TYPE);
 
-    assertMatcherMatches(elementMatcher, "create");;
+    assertMatcherMatches(elementMatcher, "create");
   }
 
   @Test
   void multipleMethodsAreSpecifiedReturnMatcherForMultipleMethods() throws NoSuchMethodException {
     Scope scope = createScope(true, List.of("create", "use"));
-    InspectitConfiguration configuration =
-        createConfiguration(List.of(scope));
+    InspectitConfiguration configuration = createConfiguration(List.of(scope));
     when(holder.getConfiguration()).thenReturn(configuration);
 
     ElementMatcher.Junction<MethodDescription> elementMatcher =
@@ -132,7 +131,9 @@ class ConfigurationResolverTest {
     return new InspectitConfiguration(instrumentationConfiguration);
   }
 
-  /** Create a new scope
+  /**
+   * Create a new scope
+   *
    * @param enabled the status of the scope for this test class
    * @param methodNames the method names to be instrumented
    * @return the scope with the current class as scope
@@ -145,7 +146,7 @@ class ConfigurationResolverTest {
     return createScope(enabled, null);
   }
 
-  private void assertMatcherMatches (
+  private void assertMatcherMatches(
       ElementMatcher.Junction<MethodDescription> matcher, String methodName)
       throws NoSuchMethodException {
     MethodDescription methodDescription =

--- a/src/test/java/rocks/inspectit/gepard/agent/resolver/ConfigurationResolverTest.java
+++ b/src/test/java/rocks/inspectit/gepard/agent/resolver/ConfigurationResolverTest.java
@@ -2,6 +2,7 @@ package rocks.inspectit.gepard.agent.resolver;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
+import static rocks.inspectit.gepard.agent.testutils.CustomAssertions.assertMethodDescriptionMatcherMatches;
 
 import java.util.List;
 import net.bytebuddy.description.method.MethodDescription;
@@ -86,7 +87,9 @@ class ConfigurationResolverTest {
     ElementMatcher.Junction<MethodDescription> elementMatcher =
         resolver.getMethodMatcher(TEST_TYPE);
 
-    assertMatcherMatches(elementMatcher, "create");
+    System.out.println(TEST_TYPE.getClass());
+
+    assertMethodDescriptionMatcherMatches(elementMatcher, this.getClass(), "create");
   }
 
   @Test
@@ -98,8 +101,8 @@ class ConfigurationResolverTest {
     ElementMatcher.Junction<MethodDescription> elementMatcher =
         resolver.getMethodMatcher(TEST_TYPE);
 
-    assertMatcherMatches(elementMatcher, "use");
-    assertMatcherMatches(elementMatcher, "create");
+    assertMethodDescriptionMatcherMatches(elementMatcher, this.getClass(), "use");
+    assertMethodDescriptionMatcherMatches(elementMatcher, this.getClass(), "create");
   }
 
   @Test
@@ -117,8 +120,8 @@ class ConfigurationResolverTest {
     ElementMatcher.Junction<MethodDescription> elementMatcher =
         resolver.getMethodMatcher(TEST_TYPE);
 
-    assertMatcherMatches(elementMatcher, "use");
-    assertMatcherMatches(elementMatcher, "create");
+    assertMethodDescriptionMatcherMatches(elementMatcher, this.getClass(), "use");
+    assertMethodDescriptionMatcherMatches(elementMatcher, this.getClass(), "create");
   }
 
   /**
@@ -144,15 +147,6 @@ class ConfigurationResolverTest {
 
   private Scope createScope(boolean enabled) {
     return createScope(enabled, null);
-  }
-
-  private void assertMatcherMatches(
-      ElementMatcher.Junction<MethodDescription> matcher, String methodName)
-      throws NoSuchMethodException {
-    MethodDescription methodDescription =
-        new MethodDescription.ForLoadedMethod(
-            ConfigurationResolverTest.class.getMethod(methodName));
-    assertTrue(matcher.matches(methodDescription));
   }
 
   // Mock methods for the matcher test. Has to be public to be visible.

--- a/src/test/java/rocks/inspectit/gepard/agent/resolver/matcher/CustomElementMatchersTest.java
+++ b/src/test/java/rocks/inspectit/gepard/agent/resolver/matcher/CustomElementMatchersTest.java
@@ -1,29 +1,33 @@
 package rocks.inspectit.gepard.agent.resolver.matcher;
 
+import static org.junit.jupiter.api.Assertions.*;
+import static rocks.inspectit.gepard.agent.testutils.CustomAssertions.assertNamedElementMatcherMatches;
+
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 class CustomElementMatchersTest {
-    @Nested
-    public class NameIs {
+  @Nested
+  public class NameIs {
 
-        @Test
-        public void emptyNameReturnsNull() {
-            String method = "";
-            ElementMatcher.Junction<NamedElement> result = CustomElementMatchers.nameIs(method);
-            assertNull(result);
-        }
-
-        @Test
-        public void validNameMatcherIsReturned () {
-            String method = "testMethod";
-            ElementMatcher.Junction<NamedElement> result = CustomElementMatchers.nameIs(method);
-            assertNotNull(result);
-        }
+    @Test
+    public void emptyNameReturnsNull() {
+      String method = "";
+      ElementMatcher.Junction<NamedElement> result = CustomElementMatchers.nameIs(method);
+      assertNull(result);
     }
 
+    @Test
+    public void validNameMatcherIsReturned() throws NoSuchMethodException {
+      String method = "testMethod";
+      ElementMatcher.Junction<NamedElement> result = CustomElementMatchers.nameIs(method);
+      assert result != null;
+
+      assertNamedElementMatcherMatches(result, this.getClass(), method);
+    }
+
+    public void testMethod() {}
+  }
 }

--- a/src/test/java/rocks/inspectit/gepard/agent/resolver/matcher/CustomElementMatchersTest.java
+++ b/src/test/java/rocks/inspectit/gepard/agent/resolver/matcher/CustomElementMatchersTest.java
@@ -1,0 +1,29 @@
+package rocks.inspectit.gepard.agent.resolver.matcher;
+
+import net.bytebuddy.description.NamedElement;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CustomElementMatchersTest {
+    @Nested
+    public class NameIs {
+
+        @Test
+        public void emptyNameReturnsNull() {
+            String method = "";
+            ElementMatcher.Junction<NamedElement> result = CustomElementMatchers.nameIs(method);
+            assertNull(result);
+        }
+
+        @Test
+        public void validNameMatcherIsReturned () {
+            String method = "testMethod";
+            ElementMatcher.Junction<NamedElement> result = CustomElementMatchers.nameIs(method);
+            assertNotNull(result);
+        }
+    }
+
+}

--- a/src/test/java/rocks/inspectit/gepard/agent/resolver/matcher/MatcherChainBuilderTest.java
+++ b/src/test/java/rocks/inspectit/gepard/agent/resolver/matcher/MatcherChainBuilderTest.java
@@ -1,5 +1,8 @@
 package rocks.inspectit.gepard.agent.resolver.matcher;
 
+import static net.bytebuddy.matcher.ElementMatchers.not;
+import static org.junit.jupiter.api.Assertions.*;
+
 import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
 import org.junit.jupiter.api.Assertions;
@@ -7,131 +10,127 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static net.bytebuddy.matcher.ElementMatchers.not;
-import static org.junit.jupiter.api.Assertions.*;
-
 class MatcherChainBuilderTest {
-    private MatcherChainBuilder<Object> builder;
+  private MatcherChainBuilder<Object> builder;
 
-    private ElementMatcher.Junction<Object> anyMatcher = ElementMatchers.any();
+  private final ElementMatcher.Junction<Object> anyMatcher = ElementMatchers.any();
 
-    @BeforeEach
-    public void beforeEach() {
-        builder = new MatcherChainBuilder<>();
+  @BeforeEach
+  public void beforeEach() {
+    builder = new MatcherChainBuilder<>();
+  }
+
+  @Nested
+  public class Or {
+
+    @Test
+    public void nullMatcher() {
+      builder.or(null);
+
+      assertNull(builder.build());
+      assertTrue(builder.isEmpty());
     }
 
-    @Nested
-    public class Or {
+    @Test
+    public void singleMatcher() {
+      builder.or(anyMatcher);
 
-        @Test
-        public void nullMatcher() {
-            builder.or(null);
-
-            assertNull(builder.build());
-            assertTrue(builder.isEmpty());
-        }
-
-        @Test
-        public void singleMatcher() {
-            builder.or(anyMatcher);
-
-            Assertions.assertEquals(builder.build(), anyMatcher);
-            assertFalse(builder.isEmpty());
-        }
-
-        @Test
-        public void multipleMatcher() {
-            builder.or(anyMatcher);
-            builder.or(anyMatcher);
-
-            assertEquals(builder.build(), anyMatcher.or(anyMatcher));
-        }
-
-        @Test
-        public void nullOnNotEmpty() {
-            builder.or(anyMatcher);
-            builder.or(null);
-
-            assertEquals(builder.build(), anyMatcher);
-        }
+      Assertions.assertEquals(builder.build(), anyMatcher);
+      assertFalse(builder.isEmpty());
     }
 
-    @Nested
-    public class And {
+    @Test
+    public void multipleMatcher() {
+      builder.or(anyMatcher);
+      builder.or(anyMatcher);
 
-        @Test
-        public void nullMatcher() {
-            builder.and(null);
-
-            assertNull(builder.build());
-            assertTrue(builder.isEmpty());
-        }
-
-        @Test
-        public void singleMatcher() {
-            builder.and(anyMatcher);
-
-            assertEquals(builder.build(), anyMatcher);
-            assertFalse(builder.isEmpty());
-        }
-
-        @Test
-        public void multipleMatcher() {
-            builder.and(anyMatcher);
-            builder.and(anyMatcher);
-
-            assertEquals(builder.build(), anyMatcher.and(anyMatcher));
-        }
-
-        @Test
-        public void nullOnNotEmpty() {
-            builder.and(anyMatcher);
-            builder.and(null);
-
-            assertEquals(builder.build(), anyMatcher);
-        }
-
-        @Test
-        public void conditionalTrue() {
-            builder.and(true, anyMatcher);
-
-            assertEquals(builder.build(), anyMatcher);
-        }
-
-        @Test
-        public void conditionalFalse() {
-            builder.and(false, anyMatcher);
-
-            assertEquals(builder.build(), not(anyMatcher));
-        }
-
-        @Test
-        public void conditionalFalseOnNotEmpty() {
-            builder.and(anyMatcher);
-            builder.and(false, anyMatcher);
-
-            assertEquals(builder.build(), anyMatcher.and(not(anyMatcher)));
-        }
+      assertEquals(builder.build(), anyMatcher.or(anyMatcher));
     }
 
-    @Nested
-    public class IsEmpty {
+    @Test
+    public void nullOnNotEmpty() {
+      builder.or(anyMatcher);
+      builder.or(null);
 
-        @Test
-        public void empty() {
-            boolean result = builder.isEmpty();
+      assertEquals(builder.build(), anyMatcher);
+    }
+  }
 
-            assertTrue(result);
-        }
+  @Nested
+  public class And {
 
-        @Test
-        public void notEmpty() {
-            builder.and(ElementMatchers.any());
+    @Test
+    public void nullMatcher() {
+      builder.and(null);
 
-            boolean result = builder.isEmpty();
-
-            assertFalse(result);
-        }
+      assertNull(builder.build());
+      assertTrue(builder.isEmpty());
     }
 
+    @Test
+    public void singleMatcher() {
+      builder.and(anyMatcher);
+
+      assertEquals(builder.build(), anyMatcher);
+      assertFalse(builder.isEmpty());
+    }
+
+    @Test
+    public void multipleMatcher() {
+      builder.and(anyMatcher);
+      builder.and(anyMatcher);
+
+      assertEquals(builder.build(), anyMatcher.and(anyMatcher));
+    }
+
+    @Test
+    public void nullOnNotEmpty() {
+      builder.and(anyMatcher);
+      builder.and(null);
+
+      assertEquals(builder.build(), anyMatcher);
+    }
+
+    @Test
+    public void conditionalTrue() {
+      builder.and(true, anyMatcher);
+
+      assertEquals(builder.build(), anyMatcher);
+    }
+
+    @Test
+    public void conditionalFalse() {
+      builder.and(false, anyMatcher);
+
+      assertEquals(builder.build(), not(anyMatcher));
+    }
+
+    @Test
+    public void conditionalFalseOnNotEmpty() {
+      builder.and(anyMatcher);
+      builder.and(false, anyMatcher);
+
+      assertEquals(builder.build(), anyMatcher.and(not(anyMatcher)));
+    }
+  }
+
+  @Nested
+  public class IsEmpty {
+
+    @Test
+    public void empty() {
+      boolean result = builder.isEmpty();
+
+      assertTrue(result);
+    }
+
+    @Test
+    public void notEmpty() {
+      builder.and(ElementMatchers.any());
+
+      boolean result = builder.isEmpty();
+
+      assertFalse(result);
+    }
+  }
 }

--- a/src/test/java/rocks/inspectit/gepard/agent/resolver/matcher/MatcherChainBuilderTest.java
+++ b/src/test/java/rocks/inspectit/gepard/agent/resolver/matcher/MatcherChainBuilderTest.java
@@ -1,0 +1,137 @@
+package rocks.inspectit.gepard.agent.resolver.matcher;
+
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static net.bytebuddy.matcher.ElementMatchers.not;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MatcherChainBuilderTest {
+    private MatcherChainBuilder<Object> builder;
+
+    private ElementMatcher.Junction<Object> anyMatcher = ElementMatchers.any();
+
+    @BeforeEach
+    public void beforeEach() {
+        builder = new MatcherChainBuilder<>();
+    }
+
+    @Nested
+    public class Or {
+
+        @Test
+        public void nullMatcher() {
+            builder.or(null);
+
+            assertNull(builder.build());
+            assertTrue(builder.isEmpty());
+        }
+
+        @Test
+        public void singleMatcher() {
+            builder.or(anyMatcher);
+
+            Assertions.assertEquals(builder.build(), anyMatcher);
+            assertFalse(builder.isEmpty());
+        }
+
+        @Test
+        public void multipleMatcher() {
+            builder.or(anyMatcher);
+            builder.or(anyMatcher);
+
+            assertEquals(builder.build(), anyMatcher.or(anyMatcher));
+        }
+
+        @Test
+        public void nullOnNotEmpty() {
+            builder.or(anyMatcher);
+            builder.or(null);
+
+            assertEquals(builder.build(), anyMatcher);
+        }
+    }
+
+    @Nested
+    public class And {
+
+        @Test
+        public void nullMatcher() {
+            builder.and(null);
+
+            assertNull(builder.build());
+            assertTrue(builder.isEmpty());
+        }
+
+        @Test
+        public void singleMatcher() {
+            builder.and(anyMatcher);
+
+            assertEquals(builder.build(), anyMatcher);
+            assertFalse(builder.isEmpty());
+        }
+
+        @Test
+        public void multipleMatcher() {
+            builder.and(anyMatcher);
+            builder.and(anyMatcher);
+
+            assertEquals(builder.build(), anyMatcher.and(anyMatcher));
+        }
+
+        @Test
+        public void nullOnNotEmpty() {
+            builder.and(anyMatcher);
+            builder.and(null);
+
+            assertEquals(builder.build(), anyMatcher);
+        }
+
+        @Test
+        public void conditionalTrue() {
+            builder.and(true, anyMatcher);
+
+            assertEquals(builder.build(), anyMatcher);
+        }
+
+        @Test
+        public void conditionalFalse() {
+            builder.and(false, anyMatcher);
+
+            assertEquals(builder.build(), not(anyMatcher));
+        }
+
+        @Test
+        public void conditionalFalseOnNotEmpty() {
+            builder.and(anyMatcher);
+            builder.and(false, anyMatcher);
+
+            assertEquals(builder.build(), anyMatcher.and(not(anyMatcher)));
+        }
+    }
+
+    @Nested
+    public class IsEmpty {
+
+        @Test
+        public void empty() {
+            boolean result = builder.isEmpty();
+
+            assertTrue(result);
+        }
+
+        @Test
+        public void notEmpty() {
+            builder.and(ElementMatchers.any());
+
+            boolean result = builder.isEmpty();
+
+            assertFalse(result);
+        }
+    }
+
+}

--- a/src/test/java/rocks/inspectit/gepard/agent/testutils/CustomAssertions.java
+++ b/src/test/java/rocks/inspectit/gepard/agent/testutils/CustomAssertions.java
@@ -1,0 +1,25 @@
+package rocks.inspectit.gepard.agent.testutils;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.bytebuddy.description.NamedElement;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+public class CustomAssertions {
+
+  public static void assertMethodDescriptionMatcherMatches(
+      ElementMatcher.Junction<MethodDescription> matcher, Class<?> clazz, String methodName)
+      throws NoSuchMethodException {
+    MethodDescription methodDescription =
+        new MethodDescription.ForLoadedMethod(clazz.getMethod(methodName));
+    assertTrue(matcher.matches(methodDescription));
+  }
+
+  public static void assertNamedElementMatcherMatches(
+      ElementMatcher.Junction<NamedElement> matcher, Class<?> clazz, String methodName)
+      throws NoSuchMethodException {
+    NamedElement element = new MethodDescription.ForLoadedMethod(clazz.getMethod(methodName));
+    assertTrue(matcher.matches(element));
+  }
+}

--- a/src/test/java/rocks/inspectit/gepard/agent/transformation/DynamicTransformerTest.java
+++ b/src/test/java/rocks/inspectit/gepard/agent/transformation/DynamicTransformerTest.java
@@ -1,0 +1,57 @@
+package rocks.inspectit.gepard.agent.transformation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import rocks.inspectit.gepard.agent.internal.instrumentation.InstrumentationState;
+import rocks.inspectit.gepard.agent.internal.instrumentation.InstrumentedType;
+import rocks.inspectit.gepard.agent.resolver.ConfigurationResolver;
+
+class DynamicTransformerTest {
+
+  @Mock private ConfigurationResolver resolver = mock(ConfigurationResolver.class);
+
+  @Mock private InstrumentationState instrumentationState = mock(InstrumentationState.class);
+
+  @Mock DynamicType.Builder<?> builder = mock(DynamicType.Builder.class);
+
+  @Test
+  void testTransformTransformsOnShouldInstrumentFalse() {
+
+    Class<?> TEST_CLASS = DynamicTransformerTest.class;
+
+    DynamicTransformer transformer = new DynamicTransformer(resolver, instrumentationState);
+
+    TypeDescription typeDescription = TypeDescription.ForLoadedType.of(TEST_CLASS);
+
+    when(resolver.shouldInstrument(typeDescription)).thenReturn(true);
+
+    transformer.transform(builder, typeDescription, TEST_CLASS.getClassLoader(), null, null);
+
+    verify(builder).visit(any());
+    verify(instrumentationState).addInstrumentedType(any());
+  }
+
+  @Test
+  void testTransformerDoesNotTransformOnShouldInstrumentFalse() {
+
+    Class<?> TEST_CLASS = DynamicTransformerTest.class;
+
+    DynamicTransformer transformer = new DynamicTransformer(resolver, instrumentationState);
+
+    TypeDescription typeDescription = TypeDescription.ForLoadedType.of(TEST_CLASS);
+
+    when(resolver.shouldInstrument(typeDescription)).thenReturn(false);
+
+    when(instrumentationState.isInstrumented(any(InstrumentedType.class))).thenReturn(true);
+
+    transformer.transform(builder, typeDescription, TEST_CLASS.getClassLoader(), null, null);
+
+    verify(builder, never()).visit(any());
+    verify(instrumentationState).invalidateInstrumentedType(any());
+  }
+}

--- a/src/test/java/rocks/inspectit/gepard/agent/transformation/DynamicTransformerTest.java
+++ b/src/test/java/rocks/inspectit/gepard/agent/transformation/DynamicTransformerTest.java
@@ -20,7 +20,7 @@ class DynamicTransformerTest {
   @Mock DynamicType.Builder<?> builder = mock(DynamicType.Builder.class);
 
   @Test
-  void testTransformTransformsOnShouldInstrumentFalse() {
+  void testTransformTransformsOnShouldInstrumentTrue() {
 
     Class<?> TEST_CLASS = DynamicTransformerTest.class;
 

--- a/src/test/resources/integrationtest/configurations/empty-configuration.json
+++ b/src/test/resources/integrationtest/configurations/empty-configuration.json
@@ -1,5 +1,5 @@
 {
-  "instrumentationConfiguration": {
+  "instrumentation": {
     "scopes": []
   }
 }

--- a/src/test/resources/integrationtest/configurations/multiple-scopes.json
+++ b/src/test/resources/integrationtest/configurations/multiple-scopes.json
@@ -1,0 +1,20 @@
+{
+  "instrumentation": {
+    "scopes": [
+      {
+        "fqn": "io.opentelemetry.smoketest.springboot.controller.WebController",
+        "methods": ["withSpan"],
+        "enabled": true
+      },
+      {
+        "fqn": "io.opentelemetry.smoketest.springboot.controller.WebController",
+        "methods": ["greeting"],
+        "enabled": true
+      },
+      {
+        "fqn": "io.opentelemetry.smoketest.springboot.controller.PropagatingController",
+        "enabled": true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
ConfigurationResolver had only access to the first scope with the same fqn (See: InstrumentationConfiguration.java). 
Thus only one scope works, if there are multiple with the same fqn.

Now all Scopes, where the fqn is included are returned to ConfigurationResolver.

Have to flatten the MethodNames of the Scope-List now before I pass them into the MethodMatcher.


Dont like ConfigurationResolver.java:94: `ElementMatchers.namedOneOf(methodNames.toArray(String[]::new));`
Is there any prettier syntax to convert that list to a stinknormal array?